### PR TITLE
add clickable date header in week and month views

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,11 @@ class App extends React.Component {
         this.setState({ date, loading: true });
     }
 
+    viewDay(targetDate) {
+        this.setView(VIEWS.DAY);
+        this.setState( { date: targetDate, loading: true });
+    }
+
     getFilteredVisits() {
         const { search, visits } = this.state;
 
@@ -140,8 +145,8 @@ class App extends React.Component {
 
                 { loading ? <div className="spinner"></div>
                   : currentView == VIEWS.DAY ? <DayView visits={filteredVisits}/>
-                  : currentView == VIEWS.WEEK ? <WeekView date={date} visits={filteredVisits}/>
-                  : <MonthView date={date} visits={filteredVisits}/>
+                  : currentView == VIEWS.WEEK ? <WeekView date={date} visits={filteredVisits} viewDay={this.viewDay.bind(this)}/>
+                  : <MonthView date={date} visits={filteredVisits} viewDay={this.viewDay.bind(this)}/>
                 }
             </div>
         );

--- a/src/month-view.js
+++ b/src/month-view.js
@@ -28,7 +28,7 @@ const History = ({visits}) =>
     ))
 ;
 
-const GridItem = ({date, visits, sameMonth}) => {
+const GridItem = ({date, visits, sameMonth, viewDay}) => {
     let classes = "history-month-day";
     if (!sameMonth) {
         classes += " disabled";
@@ -37,7 +37,7 @@ const GridItem = ({date, visits, sameMonth}) => {
     return (
         <div className={classes}>
             <div className="history-day-header">
-                <div className="history-item">
+                <div className="history-item" onClick={() => viewDay(date)}>
                     <p>{HistoryApi.formatHistoryItem(date)}</p>
                 </div>
             </div>
@@ -48,7 +48,7 @@ const GridItem = ({date, visits, sameMonth}) => {
     );
 };
 
-const MonthView = ({visits, date}) => {
+const MonthView = ({visits, date, viewDay}) => {
     if (!visits || !date) {
         return <div>{'Something went wrong :('}</div>;
     }
@@ -60,7 +60,7 @@ const MonthView = ({visits, date}) => {
     let days = [];
     for (let i = 0; i < 35; i++) {
         const day = firstDayOfWeekBeforeMonth.clone().add(i, 'days');
-        days.push(<GridItem date={day} visits={visits[i]} sameMonth={day.isSame(date, 'month')}/>);
+        days.push(<GridItem date={day} visits={visits[i]} sameMonth={day.isSame(date, 'month')} viewDay={viewDay}/>);
     }
 
     return (

--- a/src/week-view.js
+++ b/src/week-view.js
@@ -28,10 +28,10 @@ const History = ({visits}) =>
     ))
 ;
 
-const Column = ({date, visits}) => (
+const Column = ({date, visits, viewDay}) => (
     <div className="history-week-day">
         <div className="history-day-header">
-            <div className="history-item">
+            <div className="history-item" onClick={() => viewDay(date)}>
                 <p>{HistoryApi.formatHistoryItem(date)}</p>
             </div>
         </div>
@@ -41,14 +41,14 @@ const Column = ({date, visits}) => (
     </div>
 );
 
-const WeekView = ({visits, date}) => {
+const WeekView = ({visits, date, viewDay}) => {
     if (!visits || !date) {
         return <div>{'Something went wrong :('}</div>;
     }
 
     let columns = [];
     for (let i = 0; i < 7; i++) {
-        columns.push(<Column date={date.clone().weekday(0).add(i, 'days')} visits={visits[i]}/>);
+        columns.push(<Column date={date.clone().weekday(0).add(i, 'days')} visits={visits[i]} viewDay={viewDay}/>);
     }
 
     return (


### PR DESCRIPTION
Adds feature requested in #14 

Clicking on the column and grid headers in the week and month views respectively points to the day view of the clicked date