### PR TITLE
List repeated visits to a url separately (toggleable)

### DIFF
--- a/extension/multiple-disabled-light.svg
+++ b/extension/multiple-disabled-light.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill="rgba(249, 249, 250, .8)"><path d="M4 10a1 1 0 0 0 0-2H2V3h6v1a1 1 0 0 0 2 0V2a1 1 0 0 0-1-1H1a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1zm11-4h-2l-2 2h3v5H8v-2l-2 2v1a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1z"></path><path d="M14.707 1.293a1 1 0 0 0-1.414 0L8.586 6H7a1 1 0 0 0-1 1v1.586l-4.707 4.707a1 1 0 1 0 1.414 1.414l12-12a1 1 0 0 0 0-1.414z"></path></g></svg>

--- a/extension/multiple-disabled.svg
+++ b/extension/multiple-disabled.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill="rgba(12, 12, 13, .8)"><path d="M4 10a1 1 0 0 0 0-2H2V3h6v1a1 1 0 0 0 2 0V2a1 1 0 0 0-1-1H1a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1zm11-4h-2l-2 2h3v5H8v-2l-2 2v1a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1z"></path><path d="M14.707 1.293a1 1 0 0 0-1.414 0L8.586 6H7a1 1 0 0 0-1 1v1.586l-4.707 4.707a1 1 0 1 0 1.414 1.414l12-12a1 1 0 0 0 0-1.414z"></path></g></svg>

--- a/extension/multiple-light.svg
+++ b/extension/multiple-light.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill="rgba(249, 249, 250, .8)"><path d="M15 6H7a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 7H8V8h6z"></path><path d="M4 8H2V3h6v1a1 1 0 0 0 2 0V2a1 1 0 0 0-1-1H1a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h3a1 1 0 0 0 0-2z"></path></g></svg>

--- a/extension/multiple.svg
+++ b/extension/multiple.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill="rgba(12, 12, 13, .8)"><path d="M15 6H7a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1zm-1 7H8V8h6z"></path><path d="M4 8H2V3h6v1a1 1 0 0 0 2 0V2a1 1 0 0 0-1-1H1a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h3a1 1 0 0 0 0-2z"></path></g></svg>

--- a/src/app.js
+++ b/src/app.js
@@ -105,7 +105,7 @@ class App extends React.Component {
                     });
             }
             else if (currentView === VIEWS.WEEK) {
-                HistoryApi.getWeekVisits(date)
+                HistoryApi.getWeekVisits(date, repeatedVisits)
                     .then((newVisits) => {
                         this.setState({loading: false, visits: newVisits, filteredVisits: newVisits});
                     });

--- a/src/app.js
+++ b/src/app.js
@@ -33,8 +33,14 @@ class App extends React.Component {
             date: Moment(),
             loading: true,
             search: null,
-            visits: []
+            visits: [],
+            repeatedVisits: props.repeatedVisits
         };
+    }
+
+    toggleRepeatedVisits () {
+        browser.storage.local.set({repeatedVisits: !this.state.repeatedVisits});
+        this.setState({ repeatedVisits: !this.state.repeatedVisits, loading: true });
     }
 
     setView (newView) {
@@ -83,7 +89,7 @@ class App extends React.Component {
     }
 
     render() {
-        const { currentView, date, loading, search } = this.state;
+        const { currentView, date, loading, search, repeatedVisits } = this.state;
 
         let filteredVisits = [];
         if (loading) {
@@ -138,6 +144,9 @@ class App extends React.Component {
 
                     <button className="toolbar-item-right ghost-button align-right" onClick={ () => this.previous() }><Icon default="back"/></button>
                     <button className="toolbar-item-right ghost-button" onClick={ () => this.next() }><Icon default="forward"/></button>
+                    { repeatedVisits ? <button className="toolbar-item-right ghost-button" title="Hide Repeated Visits" onClick={ () => this.toggleRepeatedVisits() }><Icon default="multiple"/></button>
+                      : <button className="toolbar-item-right ghost-button" title="Show Repeated Visits" onClick={ () => this.toggleRepeatedVisits() }><Icon default="multiple-disabled"/></button>
+                    }
                     <button className="toolbar-item-right default-button" onClick={ () => this.setView(VIEWS.DAY) }>Day</button>
                     <button className="toolbar-item-right default-button" onClick={ () => this.setView(VIEWS.WEEK) }>Week</button>
                     <button className="toolbar-item-right default-button" onClick={ () => this.setView(VIEWS.MONTH) }>Month</button>

--- a/src/app.js
+++ b/src/app.js
@@ -111,7 +111,7 @@ class App extends React.Component {
                     });
             }
             else if (currentView === VIEWS.MONTH) {
-                HistoryApi.getMonthVisits(date)
+                HistoryApi.getMonthVisits(date, repeatedVisits)
                     .then((newVisits) => {
                         this.setState({loading: false, visits: newVisits, filteredVisits: newVisits});
                     });

--- a/src/app.js
+++ b/src/app.js
@@ -94,7 +94,7 @@ class App extends React.Component {
         let filteredVisits = [];
         if (loading) {
             if (currentView === VIEWS.DAY) {
-                HistoryApi.getDayVisits(date)
+                HistoryApi.getDayVisits(date, repeatedVisits)
                     .then((newVisits) => {
                         this.setState({loading: false, visits: newVisits, filteredVisits: newVisits});
                     });

--- a/src/app.js
+++ b/src/app.js
@@ -28,13 +28,18 @@ class App extends React.Component {
             currentView = VIEWS.WEEK;
         }
 
+        let repeatedVisits = props.repeatedVisits;
+        if (repeatedVisits == null || repeatedVisits == undefined) {
+            repeatedVisits = false;
+        }
+
         this.state = {
             currentView,
             date: Moment(),
             loading: true,
             search: null,
             visits: [],
-            repeatedVisits: props.repeatedVisits
+            repeatedVisits
         };
     }
 

--- a/src/history-api.js
+++ b/src/history-api.js
@@ -70,19 +70,15 @@ export default class HistoryApi {
 
         if (repeatedVisits) {
             for (const historyItem of historyItems) {
-                if (historyItem.visitCount == 1){ // then add the one historyItem
-                  daysArray[Moment(historyItem.lastVisitTime).weekday()].push(historyItem);
-                } else {
-                    let visits = await browser.history.getVisits({ url: historyItem.url });
-                    // add all separate visits
-                    for (const visit of visits) {
-                        if (visit.visitTime !== undefined
-                            && Moment(visit.visitTime).isAfter(dateStart)
-                            && Moment(visit.visitTime).isBefore(dateEnd)) {
-                            // create new HistoryItem's with different lastVisitTime
-                            var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
-                            daysArray[Moment(newHistoryItem.lastVisitTime).weekday()].push(newHistoryItem);
-                        }
+                let visits = await browser.history.getVisits({ url: historyItem.url });
+                // add all separate visits
+                for (const visit of visits) {
+                    if (visit.visitTime !== undefined
+                        && Moment(visit.visitTime).isAfter(dateStart)
+                        && Moment(visit.visitTime).isBefore(dateEnd)) {
+                        // create new HistoryItem's with different lastVisitTime
+                        var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
+                        daysArray[Moment(newHistoryItem.lastVisitTime).weekday()].push(newHistoryItem);
                     }
                 }
             }
@@ -120,22 +116,18 @@ export default class HistoryApi {
 
         if (repeatedVisits) {
             for (const historyItem of historyItems) {
-                if (historyItem.visitCount == 1){ // then add the one historyItem
-                  daysArray[Moment(historyItem.lastVisitTime).weekday()].push(historyItem);
-                } else {
-                    let visits = await browser.history.getVisits({ url: historyItem.url });
-                    // add all separate visits
-                    for (const visit of visits) {
-                        if (visit.visitTime !== undefined
-                            && Moment(visit.visitTime).isAfter(dateStart)
-                            && Moment(visit.visitTime).isBefore(dateEnd)) {
-                            // create new HistoryItem's with different lastVisitTime
-                            var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
-                            const idx = Moment(newHistoryItem.lastVisitTime).dayOfYear() - dateStart.dayOfYear();
-                            if (idx < 0 || idx >= 35)
-                                continue;
-                            daysArray[idx].push(newHistoryItem);
-                        }
+                let visits = await browser.history.getVisits({ url: historyItem.url });
+                // add all separate visits
+                for (const visit of visits) {
+                    if (visit.visitTime !== undefined
+                        && Moment(visit.visitTime).isAfter(dateStart)
+                        && Moment(visit.visitTime).isBefore(dateEnd)) {
+                        // create new HistoryItem's with different lastVisitTime
+                        var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
+                        const idx = Moment(newHistoryItem.lastVisitTime).dayOfYear() - dateStart.dayOfYear();
+                        if (idx < 0 || idx >= 35)
+                            continue;
+                        daysArray[idx].push(newHistoryItem);
                     }
                 }
             }

--- a/src/history-api.js
+++ b/src/history-api.js
@@ -88,7 +88,7 @@ export default class HistoryApi {
             }
         }
 
-        return daysArray;
+        return daysArray.map(day => day.sort((a, b) => b.lastVisitTime - a.lastVisitTime));
     }
 
     /**
@@ -140,7 +140,7 @@ export default class HistoryApi {
             }
         }
 
-        return daysArray;
+        return daysArray.map(day => day.sort((a, b) => b.lastVisitTime - a.lastVisitTime));
     }
 
     static formatDayHeader(date) {

--- a/src/history-api.js
+++ b/src/history-api.js
@@ -19,21 +19,32 @@ export default class HistoryApi {
             maxResults: Number.MAX_SAFE_INTEGER
         });
 
+        var allHistoryItems = []; // multi-visits separated
         for (const historyItem of historyItems) {
             let visits = await browser.history.getVisits({ url: historyItem.url });
 
-            // Look for the latest visit item of this day
-            const todayFirstVisit = visits.reverse().find(
-                visitItem => Moment(visitItem.visitTime).isSame(Moment(today), 'day')
-            );
+            // // Look for the latest visit item of this day
+            // const todayFirstVisit = visits.reverse().find(
+            //   visitItem => Moment(visitItem.visitTime).isSame(Moment(today), 'day')
+            // );
+            //
+            // // Sometimes there aren't any visits (during first load usually)
+            // if (todayFirstVisit) {
+            //   historyItem.lastVisitTime = todayFirstVisit.visitTime;
+            // }
 
-            // Sometimes there aren't any visits (during first load usually)
-            if (todayFirstVisit) {
-                historyItem.lastVisitTime = todayFirstVisit.visitTime;
+            // add all single visits
+            for (const visit of visits) {
+              if (visit.visitTime !== undefined) {
+                // create new HistoryItem's with different lastVisitTime
+                var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
+                allHistoryItems.push(newHistoryItem);
+              }
             }
         }
 
-        return [historyItems.sort((a, b) => b.lastVisitTime - a.lastVisitTime)];
+        // return [historyItems.sort((a, b) => b.lastVisitTime - a.lastVisitTime)];
+        return [allHistoryItems.sort((a, b) => b.lastVisitTime - a.lastVisitTime)];
     }
 
     /**

--- a/src/history-api.js
+++ b/src/history-api.js
@@ -53,7 +53,7 @@ export default class HistoryApi {
 
     /**
      */
-    static async getWeekVisits(date) {
+    static async getWeekVisits(date, repeatedVisits) {
         const dateStart = date.clone().startOf('week').toDate();
         const dateEnd = date.clone().endOf('week').toDate();
 
@@ -66,8 +66,22 @@ export default class HistoryApi {
 
         const daysArray = new Array([], [], [], [], [], [], []);
 
-        for (const historyItem of historyItems) {
-            daysArray[Moment(historyItem.lastVisitTime).weekday()].push(historyItem);
+        if (repeatedVisits) {
+            for (const historyItem of historyItems) {
+                let visits = await browser.history.getVisits({ url: historyItem.url });
+                // add all separate visits
+                for (const visit of visits) {
+                    if (visit.visitTime !== undefined) {
+                        // create new HistoryItem's with different lastVisitTime
+                        var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
+                        daysArray[Moment(newHistoryItem.lastVisitTime).weekday()].push(newHistoryItem);
+                    }
+                }
+            }
+        } else {
+            for (const historyItem of historyItems) {
+                daysArray[Moment(historyItem.lastVisitTime).weekday()].push(historyItem);
+            }
         }
 
         return daysArray;

--- a/src/history-api.js
+++ b/src/history-api.js
@@ -26,7 +26,9 @@ export default class HistoryApi {
             if (repeatedVisits) {
                 // add all separately visits
                 for (const visit of visits) {
-                    if (visit.visitTime !== undefined) {
+                    if (visit.visitTime !== undefined
+                        && Moment(visit.visitTime).isAfter(todayStart)
+                        && Moment(visit.visitTime).isBefore(todayEnd)) {
                         // create new HistoryItem's with different lastVisitTime
                         var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
                         allHistoryItems.push(newHistoryItem);
@@ -68,13 +70,19 @@ export default class HistoryApi {
 
         if (repeatedVisits) {
             for (const historyItem of historyItems) {
-                let visits = await browser.history.getVisits({ url: historyItem.url });
-                // add all separate visits
-                for (const visit of visits) {
-                    if (visit.visitTime !== undefined) {
-                        // create new HistoryItem's with different lastVisitTime
-                        var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
-                        daysArray[Moment(newHistoryItem.lastVisitTime).weekday()].push(newHistoryItem);
+                if (historyItem.visitCount == 1){ // then add the one historyItem
+                  daysArray[Moment(historyItem.lastVisitTime).weekday()].push(historyItem);
+                } else {
+                    let visits = await browser.history.getVisits({ url: historyItem.url });
+                    // add all separate visits
+                    for (const visit of visits) {
+                        if (visit.visitTime !== undefined
+                            && Moment(visit.visitTime).isAfter(dateStart)
+                            && Moment(visit.visitTime).isBefore(dateEnd)) {
+                            // create new HistoryItem's with different lastVisitTime
+                            var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
+                            daysArray[Moment(newHistoryItem.lastVisitTime).weekday()].push(newHistoryItem);
+                        }
                     }
                 }
             }
@@ -112,16 +120,22 @@ export default class HistoryApi {
 
         if (repeatedVisits) {
             for (const historyItem of historyItems) {
-                let visits = await browser.history.getVisits({ url: historyItem.url });
-                // add all separate visits
-                for (const visit of visits) {
-                    if (visit.visitTime !== undefined) {
-                        // create new HistoryItem's with different lastVisitTime
-                        var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
-                        const idx = Moment(newHistoryItem.lastVisitTime).dayOfYear() - dateStart.dayOfYear();
-                        if (idx < 0 || idx >= 35)
-                            continue;
-                        daysArray[idx].push(newHistoryItem);
+                if (historyItem.visitCount == 1){ // then add the one historyItem
+                  daysArray[Moment(historyItem.lastVisitTime).weekday()].push(historyItem);
+                } else {
+                    let visits = await browser.history.getVisits({ url: historyItem.url });
+                    // add all separate visits
+                    for (const visit of visits) {
+                        if (visit.visitTime !== undefined
+                            && Moment(visit.visitTime).isAfter(dateStart)
+                            && Moment(visit.visitTime).isBefore(dateEnd)) {
+                            // create new HistoryItem's with different lastVisitTime
+                            var newHistoryItem = {title:historyItem.title, url:historyItem.url, lastVisitTime:visit.visitTime};
+                            const idx = Moment(newHistoryItem.lastVisitTime).dayOfYear() - dateStart.dayOfYear();
+                            if (idx < 0 || idx >= 35)
+                                continue;
+                            daysArray[idx].push(newHistoryItem);
+                        }
                     }
                 }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ async function main() {
     Moment.locale(language);
 
     const data = await browser.storage.local.get();
-    ReactDOM.render(<App defaultView={data.last_visited}/>, document.getElementById('root'));
+    ReactDOM.render(<App defaultView={data.last_visited} repeatedVisits={data.repeatedVisits}/>, document.getElementById('root'));
 }
 
 main();


### PR DESCRIPTION
Hi, 
I have always been super annoyed about firefox showing only the latest visit to a url in the history and no config option to change this (e.g. when you go through your history to look for something and open an entry and it disappears from the history, because it gets pushed to the top; and it also autoscrolls to the top because of this). 
Fortunately firefox does internally save every time a url was visited, accessible from the history api for addons. Since I like your addon very much (imo by far the best vanilla history alternative), and your source code is on github, I decided to mod it and add the possibility to show every separate visit to a url. 

I did this just for myself, but if you like it, you can integrate it in you addon.
(It has a toggle button and is disabled by default)