### PR TITLE
Allow users to add keyboard shortcuts

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,6 +20,14 @@
         "default_title": "Better History"
     },
 
+    "commands": {
+        "open-better-history": {
+            "suggested_key": {
+                "default": "Ctrl+Alt+H"
+            }
+        }
+    },
+
     "permissions": [
         "history",
         "storage"

--- a/src/background.js
+++ b/src/background.js
@@ -13,5 +13,11 @@ function onVisited(historyItem) {
 browser.browserAction.onClicked.addListener(openMyPage);
 browser.history.onVisited.addListener(onVisited);
 
+browser.commands.onCommand.addListener((command) => {
+  if (command === "open-better-history") {
+      openMyPage();
+  }
+});
+
 // dev only
 //openMyPage();


### PR DESCRIPTION
Referencing #21 - Firefox doesn't allow users to override existing shortcuts at the moment, but this PR should allow users to specify their own custom shortcuts for this extension via the Add-ons Manager > Manage extension shortcuts